### PR TITLE
Update the RuntimeIncident struct to include indices + day dates

### DIFF
--- a/db/mongo/index.go
+++ b/db/mongo/index.go
@@ -236,6 +236,69 @@ var collectionIndexes = map[string][]mongo.IndexModel{
 			},
 		},
 	},
+	consts.RuntimeIncidentCollection: {
+		{
+			Keys: bson.D{
+				{Key: "guid", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "name", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "customers", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "relatedAlerts.ruleID", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "relatedAlerts.timestamp", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "guid", Value: 1},
+				// {Key: "customers", Value: 1},
+				{Key: "relatedAlerts.timestamp", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "customers", Value: 1},
+				{Key: "incidentSeverity", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "isDismissed", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "creationTimestamp", Value: -1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "customers", Value: 1},
+				{Key: "workloadKind", Value: 1},
+				{Key: "workloadName", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "customers", Value: 1},
+				{Key: "isDismissed", Value: 1},
+			},
+		},
+	},
 }
 
 // defaultIndex is the default index for all collections unless overridden in collectionIndexes

--- a/routes/v1/runtime_incidents/routes.go
+++ b/routes/v1/runtime_incidents/routes.go
@@ -3,6 +3,7 @@ package runtime_incidents
 import (
 	"config-service/handlers"
 	"config-service/types"
+	"time"
 
 	"config-service/utils/consts"
 
@@ -18,9 +19,11 @@ func AddRoutes(g *gin.Engine) {
 			"seenAt":                  "date",
 			"timestamp":               "date",
 			"relatedAlerts.timestamp": "date",
+			"creationDayDate":         "date",
+			"resolveDayDate":          "date",
 		},
 		TimestampFieldName: ptr.String("creationTimestamp"),
-		MustExcludeFields:  []string{"relatedAlerts"},
+		MustExcludeFields:  []string{"relatedAlerts", "creationDayDate", "resolveDayDate"},
 	}
 
 	handlers.AddRoutes(g, handlers.NewRouterOptionsBuilder[*types.RuntimeIncident]().
@@ -29,7 +32,19 @@ func AddRoutes(g *gin.Engine) {
 		WithGetNamesList(false).
 		WithValidatePostUniqueName(false).
 		WithValidatePostMandatoryName(false).
+		WithPutValidators(incidentUpdateResolveDayDate).
 		WithSchemaInfo(schemaInfo).
 		WithV2ListSearch(true).
 		Get()...)
+}
+
+func incidentUpdateResolveDayDate(c *gin.Context, docs []*types.RuntimeIncident) (verifiedDocs []*types.RuntimeIncident, valid bool) {
+	for _, doc := range docs {
+		if doc.IsDismissed && doc.ResolveDayDate == nil {
+			nowUtc := time.Now().UTC()
+			nowUtc = time.Date(nowUtc.Year(), nowUtc.Month(), nowUtc.Day(), 0, 0, 0, 0, time.UTC)
+			doc.ResolveDayDate = &nowUtc
+		}
+	}
+	return docs, true
 }

--- a/service_test.go
+++ b/service_test.go
@@ -1625,66 +1625,72 @@ func getIncidentsMocks() []*types.RuntimeIncident {
 	ts, _ := time.Parse(time.RFC3339, "2022-04-28T14:00:00.147901Z")
 	runtimeIncidents := []*types.RuntimeIncident{
 		{
-			PortalBase: armotypes.PortalBase{
-				Name: "incident1",
-				GUID: "1c0e9d28-7e71-4370-999e-9b3e8f69a648",
-			},
-			RuntimeAlert: armotypes.RuntimeAlert{
-				RuntimeAlertK8sDetails: armotypes.RuntimeAlertK8sDetails{
-					ClusterName: "cluster1",
-					Namespace:   "namespace1",
+			RuntimeIncident: armotypes.RuntimeIncident{
+				PortalBase: armotypes.PortalBase{
+					Name: "incident1",
+					GUID: "1c0e9d28-7e71-4370-999e-9b3e8f69a648",
 				},
-			},
-			Severity: "low",
-			RuntimeIncidentResource: armotypes.RuntimeIncidentResource{
-				Designators: identifiers.PortalDesignator{
-					DesignatorType: identifiers.DesignatorAttributes,
-					Attributes:     map[string]string{},
+				RuntimeAlert: armotypes.RuntimeAlert{
+					RuntimeAlertK8sDetails: armotypes.RuntimeAlertK8sDetails{
+						ClusterName: "cluster1",
+						Namespace:   "namespace1",
+					},
+				},
+				Severity: "low",
+				RuntimeIncidentResource: armotypes.RuntimeIncidentResource{
+					Designators: identifiers.PortalDesignator{
+						DesignatorType: identifiers.DesignatorAttributes,
+						Attributes:     map[string]string{},
+					},
 				},
 			},
 		},
 		{
-			PortalBase: armotypes.PortalBase{
-				Name: "incident2",
-				GUID: "1c0e9d28-7e71-4370-999e-9b3e8f69a647",
-			},
-			RuntimeIncidentResource: armotypes.RuntimeIncidentResource{
-				Designators: identifiers.PortalDesignator{
-					DesignatorType: identifiers.DesignatorAttributes,
-					Attributes:     map[string]string{},
+			RuntimeIncident: armotypes.RuntimeIncident{
+				PortalBase: armotypes.PortalBase{
+					Name: "incident2",
+					GUID: "1c0e9d28-7e71-4370-999e-9b3e8f69a647",
 				},
+				RuntimeIncidentResource: armotypes.RuntimeIncidentResource{
+					Designators: identifiers.PortalDesignator{
+						DesignatorType: identifiers.DesignatorAttributes,
+						Attributes:     map[string]string{},
+					},
+				},
+				Severity: "high",
 			},
-			Severity: "high",
 		},
 		{
-			PortalBase: armotypes.PortalBase{
-				Name: "incident3",
-				GUID: "1c0e9d28-7e71-4370-999e-9b3e8f69a646",
-			},
-			RuntimeAlert: armotypes.RuntimeAlert{
-				BaseRuntimeAlert: armotypes.BaseRuntimeAlert{
-					Timestamp: ts,
+			RuntimeIncident: armotypes.RuntimeIncident{
+				PortalBase: armotypes.PortalBase{
+					Name: "incident3",
+					GUID: "1c0e9d28-7e71-4370-999e-9b3e8f69a646",
 				},
-			},
-			Severity: "medium",
-			RelatedAlerts: []armotypes.RuntimeAlert{
-				{
-					Message:  "msg1",
-					HostName: "host1",
+				RuntimeAlert: armotypes.RuntimeAlert{
+					BaseRuntimeAlert: armotypes.BaseRuntimeAlert{
+						Timestamp: ts,
+					},
 				},
-				{
-					Message:  "msg2",
-					HostName: "host2",
+				Severity: "medium",
+				RelatedAlerts: []armotypes.RuntimeAlert{
+					{
+						Message:  "msg1",
+						HostName: "host1",
+					},
+					{
+						Message:  "msg2",
+						HostName: "host2",
+					},
+					{
+						Message:  "msg3",
+						HostName: "host3",
+					},
 				},
-				{
-					Message:  "msg3",
-					HostName: "host3",
-				},
-			},
-			RuntimeIncidentResource: armotypes.RuntimeIncidentResource{
-				Designators: identifiers.PortalDesignator{
-					DesignatorType: identifiers.DesignatorAttributes,
-					Attributes:     map[string]string{},
+				RuntimeIncidentResource: armotypes.RuntimeIncidentResource{
+					Designators: identifiers.PortalDesignator{
+						DesignatorType: identifiers.DesignatorAttributes,
+						Attributes:     map[string]string{},
+					},
 				},
 			},
 		},
@@ -1708,7 +1714,9 @@ func (suite *MainTestSuite) TestRuntimeIncidents() {
 		skipPutTests:  false,
 	}
 	cmpFilters := cmp.FilterPath(func(p cmp.Path) bool {
-		return p.String() == "PortalBase.GUID" || p.String() == "GUID" || p.String() == "CreationTime" || p.String() == "CreationDate" || p.String() == "PortalBase.UpdatedTime" || p.String() == "UpdatedTime" || strings.HasPrefix(p.String(), "RelatedAlerts")
+		// "RuntimeIncident.RuntimeAlert.RuntimeAlertK8sDetails.HostNetwork"
+		fieldPath := p.String()
+		return fieldPath == "RuntimeIncident.PortalBase.GUID" || fieldPath == "RuntimeIncident.GUID" || fieldPath == "RuntimeIncident.CreationTime" || fieldPath == "RuntimeIncident.CreationDate" || fieldPath == "RuntimeIncident.PortalBase.UpdatedTime" || fieldPath == "RuntimeIncident.UpdatedTime" || fieldPath == "CreationDayDate" || fieldPath == "ResolveDayDate" || strings.HasPrefix(fieldPath, "RuntimeIncident.RelatedAlerts")
 	}, cmp.Ignore())
 	commonTestWithOptions(suite, consts.RuntimeIncidentPath, runtimeIncidents, modifyDocFunc,
 		testOpts, cmpFilters, ignoreTime)
@@ -1800,8 +1808,101 @@ func (suite *MainTestSuite) TestRuntimeIncidents() {
 		},
 	}
 
-	testUniqueValues(suite, consts.RuntimeIncidentPath, runtimeIncidents, uniqueValues, commonCmpFilter, ignoreTime)
+	testUniqueValues(suite, consts.RuntimeIncidentPath, runtimeIncidents, uniqueValues, cmpFilters, ignoreTime)
+}
 
+func (suite *MainTestSuite) TestRuntimeIncidentsDismiss() {
+	runtimeIncidents := getIncidentsMocks()
+	// test put is dismissed
+	w := suite.doRequest(http.MethodPost, consts.RuntimeIncidentPath, runtimeIncidents)
+	suite.Equal(http.StatusCreated, w.Code)
+	// get it first:
+	w = suite.doRequest(http.MethodGet, consts.RuntimeIncidentPath, nil)
+	suite.Equal(http.StatusOK, w.Code)
+	docs, err := decodeResponseArray[types.RuntimeIncident](w)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	incident := docs[0]
+	incident.RelatedAlerts = nil
+	incident.IsDismissed = true
+	w = suite.doRequest(http.MethodPut, consts.RuntimeIncidentPath+"/"+incident.GUID, incident)
+	suite.Equal(http.StatusOK, w.Code)
+	updateIncidents, err := decodeResponse[[]types.RuntimeIncident](w)
+	suite.NoError(err)
+	updateIncident := updateIncidents[1]
+	suite.True(updateIncident.IsDismissed)
+	nowDate := time.Now().UTC().Format(time.RFC3339[:10])
+	suite.Equal(nowDate, updateIncident.ResolveDayDate.Format(time.RFC3339[:10]))
+	suite.Equal(nowDate, updateIncident.CreationDayDate.Format(time.RFC3339[:10]))
+	nowDateUnix, _ := time.Parse(time.RFC3339[:10], nowDate)
+	nowDate = fmt.Sprintf("%d000", nowDateUnix.Unix())
+	// test unique values of dismissed/created incidents
+	uniqueValuesTests := []uniqueValueTest{
+		{
+			testName: "unique incidents created",
+			uniqueValuesRequest: armotypes.UniqueValuesRequestV2{
+				Fields: map[string]string{
+					"creationDayDate": "",
+				},
+			},
+			expectedResponse: armotypes.UniqueValuesResponseV2{
+				Fields: map[string][]string{
+					"creationDayDate": {nowDate},
+				},
+				FieldsCount: map[string][]armotypes.UniqueValuesResponseFieldsCount{
+					"creationDayDate": {
+						{
+							Field: nowDate,
+							Count: 3,
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "unique incidents resolved date",
+			uniqueValuesRequest: armotypes.UniqueValuesRequestV2{
+				Fields: map[string]string{
+					"resolveDayDate": "",
+				},
+			},
+			expectedResponse: armotypes.UniqueValuesResponseV2{
+				Fields: map[string][]string{
+					"resolveDayDate": {nowDate},
+				},
+				FieldsCount: map[string][]armotypes.UniqueValuesResponseFieldsCount{
+					"resolveDayDate": {
+						{
+							Field: nowDate,
+							Count: 1,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range uniqueValuesTests {
+		w := suite.doRequest(http.MethodPost, consts.RuntimeIncidentPath+"/uniqueValues", test.uniqueValuesRequest)
+		suite.Equal(http.StatusOK, w.Code)
+		var result armotypes.UniqueValuesResponseV2
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		if err != nil {
+			suite.FailNow(err.Error())
+		}
+		if test.expectedResponse.FieldsCount == nil {
+			//skipping fields count comparison
+			test.expectedResponse.FieldsCount = result.FieldsCount
+		}
+		suite.Equal(test.expectedResponse, result, "Unexpected result: %s", test.testName)
+	}
+
+	//bulk delete all docs
+	guids := []string{}
+	for _, doc := range docs {
+		guids = append(guids, doc.GetGUID())
+	}
+	testBulkDeleteByGUIDWithBody(suite, consts.RuntimeIncidentPath, guids)
 }
 func (suite *MainTestSuite) TestRuntimeAlerts() {
 	// feed incidents with nested alerts

--- a/types/types.go
+++ b/types/types.go
@@ -397,9 +397,13 @@ type PostureExceptionsSeverityUpdate struct {
 	SeverityScore int      `json:"severityScore" binding:"required"`
 }
 
-type RuntimeIncident armotypes.RuntimeIncident
+type RuntimeIncident struct {
+	armotypes.RuntimeIncident `json:",inline" bson:",inline"`
+	CreationDayDate           *time.Time `json:"creationDayDate,omitempty" bson:"creationDayDate,omitempty"`
+	ResolveDayDate            *time.Time `json:"resolveDayDate,omitempty" bson:"resolveDayDate,omitempty"`
+}
 
-var runtimeIncidentReadOnlyFields = append([]string{"creationTimestamp"}, commonReadOnlyFieldsV1...)
+var runtimeIncidentReadOnlyFields = append([]string{"creationTimestamp", "creationDayDate"}, commonReadOnlyFieldsV1...)
 
 func (r *RuntimeIncident) GetReadOnlyFields() []string {
 	readOnlyFields := runtimeIncidentReadOnlyFields
@@ -411,6 +415,8 @@ func (r *RuntimeIncident) GetReadOnlyFields() []string {
 
 func (r *RuntimeIncident) InitNew() {
 	r.CreationTimestamp = time.Now().UTC()
+	cDayDate := time.Date(r.CreationTimestamp.Year(), r.CreationTimestamp.Month(), r.CreationTimestamp.Day(), 0, 0, 0, 0, time.UTC)
+	r.CreationDayDate = &cDayDate
 }
 
 func (r *RuntimeIncident) GetCreationTime() *time.Time {


### PR DESCRIPTION
…lveDayDate fields. Also, update the indexes in the RuntimeIncidentCollection in the MongoDB to include the new fields. This change improves the handling of runtime incidents and allows for better querying and filtering based on creation and resolution dates.