### PR TITLE
chore: Add indexes for collections

### DIFF
--- a/db/mongo/index.go
+++ b/db/mongo/index.go
@@ -19,6 +19,13 @@ var collectionIndexes = map[string][]mongo.IndexModel{
 				{Key: "guid", Value: 1},
 			},
 		},
+		{
+			Keys: bson.D{
+				{Key: "activeSubscription.licenseType", Value: 1},
+				{Key: "activeSubscription.subscriptionStatus", Value: 1},
+				{Key: "subscription_date", Value: 1},
+			},
+		},
 	},
 	consts.UsersNotificationsCacheCollection: {
 		{
@@ -319,6 +326,34 @@ var collectionIndexes = map[string][]mongo.IndexModel{
 			Keys: bson.D{
 				{Key: "customers", Value: 1},
 				{Key: "timestamp", Value: 1},
+			},
+		},
+	},
+	consts.ClustersCollection: {
+		{
+			Keys: bson.D{
+				{Key: "_id", Value: 1},
+				{Key: "customers", Value: 1},
+			},
+		},
+	},
+	// We are paying the proce of not handling this index from config service but as a module
+	consts.TokensCollection: {
+		{
+			Keys: bson.D{
+				{Key: "customerGuid", Value: 1},
+				{Key: "value", Value: 1},
+				{Key: "type", Value: 1},
+			},
+		},
+	},
+	consts.VulnerabilityExceptionPolicyCollection: {
+		{
+			Keys: bson.D{
+				{Key: "attributes.namespaceOnly", Value: 1},
+				{Key: "designators.attributes.cluster", Value: 1},
+				{Key: "designators.attributes.namespace", Value: 1},
+				{Key: "customers", Value: 1},
 			},
 		},
 	},

--- a/db/mongo/index.go
+++ b/db/mongo/index.go
@@ -368,7 +368,8 @@ var collectionIndexes = map[string][]mongo.IndexModel{
 				{Key: "attributes.namespaceOnly", Value: 1},
 				{Key: "designators.attributes.cluster", Value: 1},
 				{Key: "designators.attributes.namespace", Value: 1},
-				{Key: "customers", Value: 1},
+				// can't index on both customer and designators, as they are in different arrays
+				// {Key: "customers", Value: 1},
 			},
 		},
 	},

--- a/db/mongo/index.go
+++ b/db/mongo/index.go
@@ -350,6 +350,21 @@ var collectionIndexes = map[string][]mongo.IndexModel{
 	consts.VulnerabilityExceptionPolicyCollection: {
 		{
 			Keys: bson.D{
+				{Key: "guid", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "name", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "customers", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
 				{Key: "attributes.namespaceOnly", Value: 1},
 				{Key: "designators.attributes.cluster", Value: 1},
 				{Key: "designators.attributes.namespace", Value: 1},

--- a/testers_test.go
+++ b/testers_test.go
@@ -4,7 +4,6 @@ import (
 	"config-service/types"
 	"encoding/json"
 	"fmt"
-	"os"
 	"slices"
 	"time"
 
@@ -665,12 +664,6 @@ func testGetDocsWithOptions[T types.DocContent](suite *MainTestSuite, path strin
 	slices.SortFunc(expectedDocs, sortFunc)
 	diff := cmp.Diff(docs, expectedDocs, compareOpts...)
 	suite.Equal("", diff)
-	if diff != "" {
-		jsonBytesExpected, _ := json.Marshal(expectedDocs)
-		jsonBytesActual, _ := json.Marshal(docs)
-		os.WriteFile("expected.json", jsonBytesExpected, 0644)
-		os.WriteFile("actual.json", jsonBytesActual, 0644)
-	}
 	return docs
 }
 

--- a/utils/consts/const.go
+++ b/utils/consts/const.go
@@ -53,6 +53,7 @@ const (
 	RuntimeIncidentCollection                   = "v1_runtime_incidents"
 	RuntimeIncidentPolicyCollection             = "v1_runtime_incident_policies"
 	IntegrationReferenceCollection              = "v1_integration_references"
+	TokensCollection                            = "tokens"
 
 	//Common document fields
 	IdField          = "_id"


### PR DESCRIPTION
This commit adds indexes for the following collections:
- `consts.UsersNotificationsCacheCollection`
- `consts.ClustersCollection`
- `consts.TokensCollection`
- `consts.VulnerabilityExceptionPolicyCollection`

The indexes are defined in the `db/mongo/index.go` file.